### PR TITLE
Remove Type Storage

### DIFF
--- a/src/rulerewriters.jl
+++ b/src/rulerewriters.jl
@@ -86,9 +86,9 @@ function (acr::ACRule)(term)
         args = arguments(term)
         
         for inds in permutations(eachindex(args), acr.arity)
-            result = r(Term(f, T, args[inds]))
+            result = r(Term{T}(f, args[inds]))
             if !isnothing(result)
-                return Term(f, T, [result, (args[i] for i in eachindex(args) if i ∉ inds)...])
+                return Term{T}(f, [result, (args[i] for i in eachindex(args) if i ∉ inds)...])
             end
         end
     end
@@ -109,8 +109,7 @@ function (r::RuleSet)(term, depth=-1)
     end
     if term isa Symbolic
         if term isa Term
-            expr = Term(operation(term),
-                        symtype(term),
+            expr = Term{symtype(term)}(operation(term),
                         map(t -> r(t, max(-1, depth-1)), arguments(term)))
         else
             expr = term

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -175,24 +175,37 @@ pow(x::Symbolic,y) = y==0 ? 1 : Base.:^(x,y)
 function flatten_term(⋆, args)
     # flatten nested ⋆
     flattened_args = []
+    types = Type[]
     for t in args
         if t isa Term && operation(t) === (⋆)
             append!(flattened_args, arguments(t))
         else
             push!(flattened_args, t)
         end
+        push!(types, symtype(t))
     end
-    Term(⋆, Number, flattened_args)
+    T = if (⋆) ∈ (+, *)
+         promote_type(types...)
+    else   
+        # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
+        Base.promote_op(f, types...)
+    end
+    Term{T}(⋆, flattened_args) 
 end
 
 function sort_args(f, args)
+    T = if f ∈ (+, *) # It'd be better to just pass in the type of the original term
+         promote_type(typeof.(args)...)
+    else   
+        # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
+        Base.promote_op(f, typeof.(args)...)
+    end
     if length(args) < 2
-        return Term(f, Number, args)
+        return Term{T}(f, args)
     elseif length(args) == 2
         x, y = args
-        return Term(f, Number, x <ₑ y ? [x,y] : [y,x])
+        return Term{T}(f, x <ₑ y ? [x,y] : [y,x])
     end
-
     args = args isa Tuple ? [args...] : args
-    Term(f, Number, sort(args, lt=<ₑ))
+    Term{T}(f, sort(args, lt=<ₑ))
 end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -175,37 +175,23 @@ pow(x::Symbolic,y) = y==0 ? 1 : Base.:^(x,y)
 function flatten_term(⋆, args)
     # flatten nested ⋆
     flattened_args = []
-    types = Type[]
     for t in args
         if t isa Term && operation(t) === (⋆)
             append!(flattened_args, arguments(t))
         else
             push!(flattened_args, t)
         end
-        push!(types, symtype(t))
     end
-    T = if (⋆) ∈ (+, *)
-         promote_type(types...)
-    else
-        # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
-        Base.promote_op(f, types...)
-    end
-    Term{T}(⋆, flattened_args)
+    Term(⋆, flattened_args)
 end
 
 function sort_args(f, args)
-    T = if f ∈ (+, *) # It'd be better to just pass in the type of the original term
-         promote_type(typeof.(args)...)
-    else
-        # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
-        Base.promote_op(f, typeof.(args)...)
-    end
     if length(args) < 2
-        return Term{T}(f, args)
+        return Term(f, args)
     elseif length(args) == 2
         x, y = args
-        return Term{T}(f, x <ₑ y ? [x,y] : [y,x])
+        return Term(f, x <ₑ y ? [x,y] : [y,x])
     end
     args = args isa Tuple ? [args...] : args
-    Term{T}(f, sort(args, lt=<ₑ))
+    Term(f, sort(args, lt=<ₑ))
 end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -186,17 +186,17 @@ function flatten_term(⋆, args)
     end
     T = if (⋆) ∈ (+, *)
          promote_type(types...)
-    else   
+    else
         # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
         Base.promote_op(f, types...)
     end
-    Term{T}(⋆, flattened_args) 
+    Term{T}(⋆, flattened_args)
 end
 
 function sort_args(f, args)
     T = if f ∈ (+, *) # It'd be better to just pass in the type of the original term
          promote_type(typeof.(args)...)
-    else   
+    else
         # This will just give Any for abstract types. We need to roll our own or use concrete types concrete types
         Base.promote_op(f, typeof.(args)...)
     end

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -72,6 +72,7 @@ struct Term{T} <: Symbolic{T}
     f::Any
     arguments::Any
 end
+Term(f, args) = Term{rec_promote_symtype(f, symtype.(args)...)}(f, args)
 
 operation(x::Term) = x.f
 arguments(x::Term) = x.arguments
@@ -85,7 +86,7 @@ end
 
 function term(f, args...; type = nothing)
     if type === nothing
-        T = promote_symtype(f, map(symtype, args)...)
+        T = rec_promote_symtype(f, symtype.(args)...)
     else
         T = type
     end

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -30,10 +30,8 @@ domain defaults to number.
 """
 struct Variable{T} <: Symbolic{T}
     name::Symbol
-    type::Type{T}
 end
-Variable(x) = Variable(x, Number)
-symtype(v::Variable) = v.type
+Variable(x) = Variable{Number}(x)
 Base.nameof(v::Variable) = v.name
 Base.:(==)(a::Variable, b::Variable) = a === b
 Base.:(==)(::Variable, ::Symbolic) = false
@@ -59,7 +57,7 @@ end
 macro vars(xs...)
     defs = map(xs) do x
         n, t = _name_type(x)
-        :($(esc(n)) = Variable($(Expr(:quote, n)), $(esc(t))))
+        :($(esc(n)) = Variable{$(esc(t))}($(Expr(:quote, n))))
     end
 
     Expr(:block, defs...,
@@ -72,13 +70,10 @@ end
 #--------------------
 struct Term{T} <: Symbolic{T}
     f::Any
-    type::Type{T}
     arguments::Any
 end
 
-
 operation(x::Term) = x.f
-symtype(x::Term)   = x.type
 arguments(x::Term) = x.arguments
 
 function Base.isequal(t1::Term, t2::Term)
@@ -90,12 +85,11 @@ end
 
 function term(f, args...; type = nothing)
     if type === nothing
-        t = promote_symtype(f, map(symtype, args)...)
+        T = promote_symtype(f, map(symtype, args)...)
     else
-        t = type
+        T = type
     end
-
-    Term(f, t, [args...])
+    Term{T}(f, [args...])
 end
 
 const show_simplified = Ref(true)


### PR DESCRIPTION
Closes https://github.com/shashi/SymbolicUtils.jl/issues/17

In the process of writing this, I noticed some problems with the way `flatten_term` and `sort_args` were implemented (always convert ed output symtype to `Number`) so I took the liberty of fixing that as well. 

Can be factored into a separate PR if desired. 