### PR TITLE
WIP Interface for `simplify`

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -48,3 +48,5 @@ for f in [+, *]
              type=rec_promote_symtype($f, map(symtype, (x, y, w...))...))
     end
 end
+
+promote_symtype(::typeof(identity), T) = T

--- a/src/rulesets.jl
+++ b/src/rulesets.jl
@@ -1,5 +1,6 @@
 BASIC_NUMBER_RULES = let
-    [@rule(-(~x, ~~y) => ~x + *(-1, (~~y)...))
+    [@rule(identity(~x) => ~x)
+     @rule(-(~x, ~~y) => ~x + *(-1, (~~y)...))
      @rule(~x / ~y => ~x * pow(~y, -1))
      #@rule(*(~~x, *(~~y), ~~z) => *((~~x)..., (~~y)..., (~~z)...))
      @rule(*(~~x::isnotflat(*)) => flatten_term(*, ~~x))

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -78,7 +78,7 @@ end
 <ₑ(a::T, b::S) where {T, S} = T===S ? isless(a, b) : nameof(T) < nameof(S)
 
 function <ₑ(a::Term, b::Term)
-    if arglength(a) <= 2 && arglength(b) <= 2
+    if 0 < arglength(a) <= 2 && 0 < arglength(b) <= 2
         # e.g. a < sin(a) < b ^ 2 < b
         @goto compare_args
     end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -166,17 +166,6 @@ end
 
 ### Simplification rules
 
-to_symbolic(x::Symbolic) = x
-function to_symbolic(x)
-    if !istree(x)
-        return x
-    end
-
-    Term(operation(x),
-         symtype(x),
-         map(to_symbolic, args(x)))
-end
-
 simplify(x, rules=SIMPLIFY_RULES) = RuleSet(rules)(to_symbolic(x))
 
 pow(x,y) = y==0 ? 1 : y<0 ? inv(x)^(-y) : x^y

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -166,7 +166,18 @@ end
 
 ### Simplification rules
 
-simplify(x, rules=SIMPLIFY_RULES) = RuleSet(rules)(x)
+to_symbolic(x::Symbolic) = x
+function to_symbolic(x)
+    if !istree(x)
+        return x
+    end
+
+    Term(operation(x),
+         symtype(x),
+         map(to_symbolic, args(x)))
+end
+
+simplify(x, rules=SIMPLIFY_RULES) = RuleSet(rules)(to_symbolic(x))
 
 pow(x,y) = y==0 ? 1 : y<0 ? inv(x)^(-y) : x^y
 pow(x::Symbolic,y) = y==0 ? 1 : Base.:^(x,y)

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -53,14 +53,25 @@ symtype(x::Number) = typeof(x)
 symtype(x) = Any
 symtype(::Symbolic{T}) where {T} = T
 
-# Convert other's types into Symbolic
+### End of interface
+
+"""
+    to_symbolic(x)
+
+Convert `x` to a `Symbolic` type, using the `istree`, `operation`, `arguments`,
+and optionally `symtype` if available.
+"""
 to_symbolic(x::Symbolic) = x
 function to_symbolic(x)
     if !istree(x)
         return x
     end
 
-    Term{symtype(x)}(operation(x), map(to_symbolic, args(x)))
+    if symtype(x) === Any
+        Term(operation(x), map(to_symbolic, args(x)))
+    else
+        Term(operation(x), symtype(x), map(to_symbolic, args(x)))
+    end
 end
 
 Base.one( s::Symbolic) = one( symtype(s))

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -53,6 +53,16 @@ symtype(x::Number) = typeof(x)
 symtype(x) = Any
 symtype(::Symbolic{T}) where {T} = T
 
+# Convert other's types into Symbolic
+to_symbolic(x::Symbolic) = x
+function to_symbolic(x)
+    if !istree(x)
+        return x
+    end
+
+    Term{symtype(x)}(operation(x), map(to_symbolic, args(x)))
+end
+
 Base.one( s::Symbolic) = one( symtype(s))
 Base.zero(s::Symbolic) = zero(symtype(s))
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -67,10 +67,18 @@ function to_symbolic(x)
         return x
     end
 
+    op = operation(x)
+
+    # This is a valid transformation, it helps ModelingToolkit IR
+    # get simpler for many constant related rules to apply
+    if op === identity && length(arguments(x)) === 1
+        return to_symbolic(arguments(x))
+    end
+
     if symtype(x) === Any
-        Term(operation(x), map(to_symbolic, args(x)))
+        Term(op, map(to_symbolic, arguments(x)))
     else
-        Term(operation(x), symtype(x), map(to_symbolic, args(x)))
+        Term(op, symtype(x), map(to_symbolic, arguments(x)))
     end
 end
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -69,12 +69,6 @@ function to_symbolic(x)
 
     op = operation(x)
 
-    # This is a valid transformation, it helps ModelingToolkit IR
-    # get simpler for many constant related rules to apply
-    if op === identity && length(arguments(x)) === 1
-        return to_symbolic(arguments(x))
-    end
-
     if symtype(x) === Any
         Term(op, map(to_symbolic, arguments(x)))
     else

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -4,7 +4,53 @@
 #--------------------
 abstract type Symbolic{T} end
 
-symtype(x) = typeof(x) # For types outside of SymbolicUtils
+### Interface to be defined for `simplify` to work:
+
+"""
+    istree(x::T)
+
+Check if `x` represents an expression tree. If returns true,
+it will be assumed that `operation(::T)` and `arguments(::T)`
+methods are defined. Definining these three should allow use
+of `simplify` on custom types. Optionally `symtype(x)` can be
+defined to return the expected type of the symbolic expression.
+"""
+istree(x) = false
+
+"""
+    operation(x::T)
+
+Returns the operation (a function object) performed by an expression
+tree. Called only if `istree(::T)` is true. Part of the API required
+for `simplify` to work. Other required methods are `arguments` and `istree`
+"""
+function operation end
+
+"""
+    arguments(x::T)
+
+Returns the arguments (a `Vector`) for an expression tree.
+Called only if `istree(x)` is `true`. Part of the API required
+for `simplify` to work. Other required methods are `operation` and `istree`
+"""
+function arguments end
+
+"""
+    symtype(x)
+
+The supposed type of values in the domain of x. Tracing tools can use this type to
+pick the right method to run or analyse code.
+
+This defaults to `typeof(x)` if `x` is numeric, or `Any` otherwise.
+For the types defined in this package, namely `T<:Symbolic{S}` it is `S`.
+
+Define this for your symbolic types if you want `simplify` to apply rules
+specific to numbers (such as commutativity of multiplication). Or such
+rules that may be implemented in the future.
+"""
+function symtype end
+symtype(x::Number) = typeof(x)
+symtype(x) = Any
 symtype(::Symbolic{T}) where {T} = T
 
 Base.one( s::Symbolic) = one( symtype(s))

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -67,12 +67,12 @@ function to_symbolic(x)
         return x
     end
 
-    op = operation(x)
+    op = to_symbolic(operation(x))
 
     if symtype(x) === Any
         Term(op, map(to_symbolic, arguments(x)))
     else
-        Term(op, symtype(x), map(to_symbolic, arguments(x)))
+        Term{symtype(x)}(op, map(to_symbolic, arguments(x)))
     end
 end
 
@@ -190,7 +190,7 @@ showraw(t) = showraw(stdout, t)
 # Maybe don't even need a new type, can just use Variable{FnType}
 struct FnType{X<:Tuple,Y} end
 
-fun(f,X=Tuple{Real},Y=Real) = Variable(f,FnType{X,Y})
+fun(f,X=Tuple{Real},Y=Real) = Variable{FnType{X,Y}}(f)
 
 function (f::Variable{<:FnType{X,Y}})(args...) where {X,Y}
     nrequired = fieldcount(X)


### PR DESCRIPTION
This should allow MTK and others to call `simplify` by defining 3 tiny accessor methods.

This is what @MasonProtter and I agreed on in a discussion today. To summarize:

1. This seems to be the shortest path to getting MTK to work with this right away even forgetting all the idiosyncratic differences. (the conversion should be cheap, we construct the whole tree several times during a `simplify` so this is no big deal).
2. work on the tracing analysis in can be done on this in a separate package without Symbolic <: Numeric decisions
3. Mike Innes wanted to use the rules system on Mjolnir IR, which should become possible with this.